### PR TITLE
Refactor release process: enable multi-arch, switch to Debian testing container and reset data repo

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,7 @@ on:
 jobs:
   build-debs:
     runs-on: ${{ matrix.runner }}
+    name: ${{ matrix.architecture }}
     strategy:
       matrix:
         architecture:
@@ -20,6 +21,10 @@ jobs:
             runner: ubuntu-latest
           - architecture: armhf
             runner: ubuntu-24.04-arm
+          - architecture: arm64
+            runner: ubuntu-24.04-arm
+          - architecture: riscv64
+            runner: ubuntu-latest
     steps:
       - name: Checkout the code
         uses: actions/checkout@v4
@@ -36,6 +41,7 @@ jobs:
         with:
           host-arch: ${{ matrix.architecture == 'all' && 'amd64' || matrix.architecture }}
           buildpackage-opts: --build=full
+          docker-image: debian:testing-20250407
       - name: Import GPG key
         id: import_gpg
         uses: crazy-max/ghaction-import-gpg@v6

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,14 +77,15 @@ jobs:
           merge-multiple: true
       - name: Commit changes if any
         run: |
-          git checkout data
+          git checkout --orphan data
+          git rm -rf --cached .
           mkdir -p data
           cp -rf ${{ github.workspace }}/debian/artifacts/{pool,dists} data/
           git config --global user.name "github-actions"
           git config --global user.email "github-actions@github.com"
           git add data/.
-          git diff --cached --quiet || git commit -m "Update published repository files"
-          git push
+          git diff --cached --quiet || git commit --allow-empty -m "Update published repository files"
+          git push --force --set-upstream origin data
       - name: "publish repository to web server"
         uses: peter-evans/repository-dispatch@v3
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Checkout the code
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          fetch-depth: 1
       - name: Set up build environment and artifacts directory
         run: |
           sudo apt-get update
@@ -53,6 +53,28 @@ jobs:
           reprepro -b debian/artifacts includedsc stable debian/artifacts/*.dsc
           reprepro -b debian/artifacts includedeb stable debian/artifacts/*.deb
           reprepro -b debian/artifacts export
+      - name: "Upload artifacts"
+        uses: actions/upload-artifact@v4
+        with:
+          name: artifacts-${{ matrix.architecture }}
+          path: debian/artifacts/
+          if-no-files-found: ignore
+
+  merge:
+    name: "Merge artifacts"
+    needs: build-debs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Download All Artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: debian/artifacts/
+          pattern: artifacts-*
+          merge-multiple: true
       - name: Commit changes if any
         run: |
           git checkout data

--- a/debian/artifacts/conf/distributions
+++ b/debian/artifacts/conf/distributions
@@ -2,7 +2,7 @@ Origin: Armbian
 Label: Armbian Package Archive APA
 Suite: stable
 Codename: current
-Architectures: amd64 armhf source
+Architectures: amd64 arm64 riscv64 armhf source
 Components: main
 Description: packages provided by the Armbian project
 SignWith: DF00FAF1C577104B50BF1D0093D6889F9F0E78D5


### PR DESCRIPTION
- Enable support for additional architectures (e.g. riscv64)
- Switch build container to Debian testing with fixed tag (stable lacks riscv64)
- Show architecture name instead of runner name in GitHub job logs
- Drop git history in `data` repository to retain only latest files

Closing https://github.com/armbian/apa/issues/12
Closing https://github.com/armbian/apa/issues/11
Closing https://github.com/armbian/apa/issues/6