### PR TITLE
iron out bugs in APA

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -20,6 +20,7 @@ Depends:
  e2fsprogs,
  initramfs-tools,
  iproute2,
+ iputils-ping,
  logrotate,
  linux-base,
  nano|vim,


### PR DESCRIPTION
- `armbian-common`: copy some deps/recs/suggests from armbian/build's CLI configs
- add `armbian-desktop-cinnamon` and `armbian-common-i3-wm`
  - `i3-wm` is part of armbian/build, but there are reasons to consider abandoning it, leave it to the users to do themselves. To do this, remove it from `config/desktop/*/environments/` first.
- `armbian-bsp` shouldn't be required by `armbian-common` as it contains hardware-specific components
- `iputils-ping` is a build dependency, but only for the existence, not use, of `/bin/ping`
  - this is weird and might be worth eliminating. but we have to [fix it on the `armbian/build` side first.](https://github.com/armbian/apa/pull/25#issuecomment-3599285282)

re `Recommends`, many boards don't need/want `wpasupplicant`, `alsa`, `btrfs-progs` etc. but we want to install them by default b/c many ppl *do* want them.

re `kde`: https://packages.debian.org/trixie/kde-plasma-desktop says its the  minimal set of applications. I am taking them at their word.
Yes I'm a KDE user, but I haven't put enough thought as to a minimal set.
Do the same kind of dependency for `cinnamon` & `i3-wm`.

Also note the change around `linux-image`, this needs to never be installed in the `rootfs`.