### PR TITLE
armbian-common: add libcap2-bin for setcap

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -22,6 +22,7 @@ Depends:
  netplan.io|network-manager,
  openssh-server,
  pastebinit,
+ libcap2-bin,
  ${misc:Depends}
 Recommends:
  anacron,


### PR DESCRIPTION
just what it says on the tin.
this is related to issues with [ping and setuid](https://github.com/armbian/apa/pull/25#issuecomment-3618902159)