### PR TITLE
control armbian-common: move armbian-bsp to Suggests

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -17,7 +17,6 @@ Priority: required
 Essential: yes
 Architecture: all
 Depends:
- armbian-bsp|armbian-bsp-cli,
  nano|vim,
  netplan.io|network-manager,
  openssh-server,
@@ -33,6 +32,7 @@ Recommends:
  squid-deb-proxy-client|auto-apt-proxy,
  sudo
 Suggests:
+ armbian-bsp|armbian-bsp-cli,
  armbian-desktop,
  docker.io|docker-ce|podman
 


### PR DESCRIPTION
This has been discussed in #25 & is one [partial?] solution to #28.
Specifically, we cannot pull in `armbian-bsp` into the `rootfs`. We want to install it a bit later in the `armbian/build` image process, and in fact that is already done [no change is needed in `armbian/build`].