### PR TITLE
control armbian-common: pull in libpam-systemd for its dbus dependency

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -25,6 +25,7 @@ Depends:
  iproute2,
  logrotate,
  linux-base,
+ libpam-systemd,
  nano|vim,
  netplan.io|network-manager,
  openssh-server,


### PR DESCRIPTION
so [`lib/functions/rootfs/rootfs-create.sh`#L345](https://github.com/armbian/build/blob/main/lib/functions/rootfs/rootfs-create.sh#L345) expects `dbus` to be there with:
`run_host_command_logged rm -v "${SDCARD}/var/lib/dbus/machine-id"`

On desktop builds, this already gets pulled in. on `minimal` builds, not so much.

[`config/cli/common/main/packages.additional`#L35](https://github.com/armbian/build/blob/main/config/cli/common/main/packages.additional#L35) has `libpam-systemd`.
I'm not 100% sure what generates `/var/lib/dbus/machine-id`, but the `dbus` pkg's `postrm` script also deletes it.
Google suggests that `dbus-uuidgen` is used, which, in `trixie`, is in pkg `dbus-bin` which is subsequently a dependency of `dbus`.