### PR TITLE
control armbian-common: move sudo to Depends; armbian-firstlogin assumes sudo

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -31,6 +31,7 @@ Depends:
  pastebinit,
  locales,
  gnupg2,
+ sudo,
  tzdata,
  ${misc:Depends}
 Recommends:
@@ -67,7 +68,6 @@ Recommends:
  rsync,
  rsyslog,
  squid-deb-proxy-client|auto-apt-proxy,
- sudo,
  systemd-resolved,
  toilet,
  u-boot-tools,


### PR DESCRIPTION
another boring change that does exactly what the commit claims.
[`armbian-firstlogin`](https://github.com/armbian/build/blob/main/packages/bsp/common/usr/lib/armbian/armbian-firstlogin) wants to add the first user to the `sudo` group.